### PR TITLE
Bypass translation nightmare for Git and Snapshots pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -100,8 +100,8 @@ search();
 							<ul>
 								<li><a href="?id=download&amp;lang=<?php echo $lang?>"><?php echo $template['index']['download']?></a></li>
 								<li><a href="?id=releases&amp;lang=<?php echo $lang?>"><?php echo $template['index']['releases']?></a></li>
-								<li><a href="?id=snapshots&amp;lang=<?php echo $lang?>"><?php echo $template['index']['snapshots']?></a></li>
-								<li><a href="?id=git&amp;lang=<?php echo $lang?>"><?php echo $template['index']['git']?></a></li>
+								<li><a href="javascript:opendoc('https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrc's-nightly-source-or-binaries');"><?php echo $template['index']['snapshots']?></a></li>
+								<li><a href="javascript:opendoc('https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrc's-nightly-source-or-binaries#source-downloads-master');"><?php echo $template['index']['git']?></a></li>
 								<li><a href="?id=install&amp;lang=<?php echo $lang?>"><?php echo $template['index']['install']?></a></li>
 							</ul>
 						</li>


### PR DESCRIPTION
These two pages for now will link straight to Github wiki page
This is a simple and easy to revert change

http://www.kvirc.net/?id=snapshots
http://www.kvirc.net/?id=git

@DarthGandalf avoids the extremely unpleasant exchange in IRC 

Also solves the issue of maintenance of outdated and pages and helps simplify website maitenace.

If this works in due time expect a cleanup of the redundant code/files 
