### PR TITLE
temporary: make quick link come to GitHub wiki donwload page and add note on download page. PLEASE REVIEW

### DIFF
--- a/index.php
+++ b/index.php
@@ -169,8 +169,9 @@ search();
 			</div>
 			<div class="header-breadcrumbs">
 				<ul>
-					<li><a href="<?php echo $quickdownload_link?>" title="get the latest release"><?php echo $template['index']['quickdnl']?></a></li>
+					<li><a href="https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrc's-nightly-source-or-binaries" title="Get the latest build"><?php echo $template['index']['quickdnl']?></a></li>
 					<!--
+					<li><a href="<?php echo $quickdownload_link?>" title="Get the Latest Release"><?php echo $template['index']['quickdnl']?></a></li>
 					<li><a href="ftp://ftp.kvirc.de/pub/kvirc/snapshots/" title="get snapshots"><?php echo $template['index']['snapshots']?></a></li>
 					<li><a href="?id=themes&amp;lang=<?php echo $lang?>" title="themes and appearance"><?php echo $template['index']['themes']?></a></li>
 					//-->

--- a/translation/locale_en.php
+++ b/translation/locale_en.php
@@ -74,7 +74,8 @@ $template['index']['rusite']="Russian site";
 //$template['index']['frforum']="french forum";
 //$template['index']['osxsite']="OS X builds";
 // other
-$template['index']['quickdnl']="quick download";
+//$template['index']['quickdnl']="quick download";
+$template['index']['quickdnl']="Grab the latest build";
 // search
 $template['index']['search']="Search";
 $template['index']['go']="GO";
@@ -276,7 +277,7 @@ $template['donate']['alttext']="Make a donation to the KVIrc Project by PayPal";
 
 /* download.php start */
 $template['download']['title']="Downloading KVIrc";
-$template['download']['text1']="You can obtain KVIrc in three ways:";
+$template['download']['text1']="You can obtain KVIrc in three ways:<br><br><b><u>Note:</b></u> Consider downloading the current nightly Git builds instead of 4.2.0 stable</b>.<br>The current Git builds are quite stable and safe for day-to-day usage, due to the considerable enhancements, improvements and bugs fixes that are now included.<br>For more information <a href=\"https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrc%27s-nightly-source-or-binaries\">click here</a>.";
 $template['download']['text2']="Official release packages";
 $template['download']['text3']="
 	The official packages are released least frequently but are the most stable ones. Each official source package is well tested and will probably compile on your system. You also have more possibilities to find a binary package suitable for your system. The on-line FAQs and documentation refer to this type of package.";


### PR DESCRIPTION
### This adds chnages the quicklink to temporarely come to GitHub Nightly Download page and adds a note message on Downloads page asking users to consider downloading a Git snapshot instead of 4.2.0 or older.

Fed up with having to tell people stable release is pants.
