### PR TITLE
Dont put apostrophe in link

### DIFF
--- a/translation/locale_en.php
+++ b/translation/locale_en.php
@@ -277,7 +277,7 @@ $template['donate']['alttext']="Make a donation to the KVIrc Project by PayPal";
 
 /* download.php start */
 $template['download']['title']="Downloading KVIrc";
-$template['download']['text1']="You can obtain KVIrc in three ways:<br><br><b><u>Note:</b></u> Consider downloading the current nightly Git builds instead of 4.2.0 stable</b>.<br>The current Git builds are quite stable and safe for day-to-day usage, due to the considerable enhancements, improvements and bugs fixes that are now included.<br>For more information <a href=\"https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrc%27s-nightly-source-or-binaries\">click here</a>.";
+$template['download']['text1']="You can obtain KVIrc in three ways:<br><br><b><u>Note:</b></u> Consider downloading the current nightly Git builds instead of 4.2.0 stable</b>.<br>The current Git builds are quite stable and safe for day-to-day usage, due to the considerable enhancements, improvements and bugs fixes that are now included.<br>For more information <a href=\"https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrcs-nightly-source-or-binaries\">click here</a>.";
 $template['download']['text2']="Official release packages";
 $template['download']['text3']="
 	The official packages are released least frequently but are the most stable ones. Each official source package is well tested and will probably compile on your system. You also have more possibilities to find a binary package suitable for your system. The on-line FAQs and documentation refer to this type of package.";


### PR DESCRIPTION
Ensure link in webpage goes to correct page on wiki .i.e https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrcs-nightly-source-or-binaries not https://github.com/kvirc/KVIrc/wiki/Downloading-KVIrc%27s-nightly-source-or-binaries.

Before this it was going to former and that was an empty page. that should be fixed now.